### PR TITLE
fix(redirect): don't duplicate query string

### DIFF
--- a/projects/ngx-auth/core/auth.service.ts
+++ b/projects/ngx-auth/core/auth.service.ts
@@ -146,7 +146,7 @@ export class AuthService implements OnDestroy {
                          * ex: transform 'http://domain/base/private' to '/private'
                          */
                         const absUrl = value.href.replace(AuthUtils.getBaseUrl(), '');
-                        void this.router.navigateByUrl(`${absUrl}${value.search}`);
+                        void this.router.navigateByUrl(absUrl);
                     });
                 }
             })


### PR DESCRIPTION
Fix when navigation to a protected route with query string, query params shouldn't be duplicated after redirect from login

http://localhost:4200/?param=one was redirected to: http://localhost:4200/?param=one%3Fparam%3Done